### PR TITLE
Pin twillio to 5.6.0 in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,6 @@ Markdown
 Pillow
 pycrypto  # remove
 SQLAlchemy
-twilio  # make this optional
+twilio==5.6.0  # make this optional
 xlrd
 xlwt


### PR DESCRIPTION
After 5.6.0 of the twillio client the exported class changed from TwilioRestClient to Client.  TwilioRestClient is used in rhizo-server code so the client needs to be pinned to 5.60.  See https://stackoverflow.com/a/41036484 for more info.